### PR TITLE
Development

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: medication-tracker
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +39,7 @@ jobs:
 
   integration-test:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: medication-tracker
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
 
   docker:
     needs: [test, integration-test]
-    runs-on: ubuntu-latest
+    runs-on: medication-tracker
     if: github.event_name != 'pull_request'
 
     steps:
@@ -162,7 +162,7 @@ jobs:
 
   create-release:
     needs: docker
-    runs-on: ubuntu-latest
+    runs-on: medication-tracker
     if: github.ref == 'refs/heads/main'
 
     steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,6 +64,66 @@ jobs:
       - name: Run integration tests
         run: ./scripts/integration-test.sh
 
+  docker-pr:
+    needs: [test, integration-test]
+    runs-on: medication-tracker
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set PR Docker tags
+        id: pr_tags
+        run: |
+          REPO_NAME=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          echo "tags=skjall/medication-tracker:pr-${PR_NUMBER},ghcr.io/${REPO_NAME}:pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
+
+      - name: Add metadata labels to images
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            skjall/medication-tracker
+            ghcr.io/${{ github.repository }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=Medication Tracker Application (PR #${{ github.event.pull_request.number }})
+            org.opencontainers.image.licenses=MIT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.pr_tags.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=pr-${{ github.event.pull_request.number }}
+          cache-from: type=registry,ref=skjall/medication-tracker:buildcache
+          cache-to: type=registry,ref=skjall/medication-tracker:buildcache,mode=max
+
   docker:
     needs: [test, integration-test]
     runs-on: medication-tracker

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: medication-tracker
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +39,7 @@ jobs:
 
   integration-test:
     needs: test
-    runs-on: medication-tracker
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
 
   docker-pr:
     needs: [test, integration-test]
-    runs-on: medication-tracker
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
 
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   docker:
     needs: [test, integration-test]
-    runs-on: medication-tracker
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
 
     steps:
@@ -222,7 +222,7 @@ jobs:
 
   create-release:
     needs: docker
-    runs-on: medication-tracker
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
 
     steps:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,95 @@
+name: PR Image Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup-pr-images:
+    runs-on: medication-tracker
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete PR images from Docker Hub
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          TAG="pr-${PR_NUMBER}"
+          
+          echo "Deleting Docker Hub image: skjall/medication-tracker:${TAG}"
+          
+          # Get Docker Hub token
+          TOKEN=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -d '{"username":"'${{ secrets.DOCKERHUB_USERNAME }}'","password":"'${{ secrets.DOCKERHUB_TOKEN }}'"}' \
+            https://hub.docker.com/v2/users/login/ | jq -r .token)
+          
+          if [ ! -z "$TOKEN" ]; then
+            # Delete the specific tag
+            curl -X DELETE \
+              -H "Authorization: Bearer ${TOKEN}" \
+              "https://hub.docker.com/v2/repositories/skjall/medication-tracker/tags/${TAG}/"
+            
+            echo "Docker Hub image tag ${TAG} deletion requested"
+          else
+            echo "Failed to authenticate with Docker Hub"
+          fi
+
+      - name: Delete PR images from GitHub Container Registry
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          TAG="pr-${PR_NUMBER}"
+          REPO_NAME=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          
+          echo "Deleting GitHub Container Registry image: ghcr.io/${REPO_NAME}:${TAG}"
+          
+          # Get package versions for the PR tag
+          PACKAGE_VERSION_ID=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/user/packages/container/$(basename ${REPO_NAME})/versions" \
+            --jq '.[] | select(.metadata.container.tags[] | contains("'${TAG}'")) | .id' \
+            2>/dev/null || echo "")
+          
+          if [ ! -z "$PACKAGE_VERSION_ID" ]; then
+            echo "Found package version ID: ${PACKAGE_VERSION_ID}"
+            
+            # Delete the package version
+            gh api \
+              --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/user/packages/container/$(basename ${REPO_NAME})/versions/${PACKAGE_VERSION_ID}"
+            
+            echo "GitHub Container Registry image deleted successfully"
+          else
+            echo "No matching package version found for tag ${TAG} (may have been already deleted or doesn't exist)"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          echo "### PR Image Cleanup Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Cleaned up images for PR #${PR_NUMBER}:" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker Hub: \`skjall/medication-tracker:pr-${PR_NUMBER}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- GitHub Container Registry: \`ghcr.io/${{ github.repository }}:pr-${PR_NUMBER}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -9,8 +9,8 @@ permissions:
 
 jobs:
   cleanup-pr-images:
-    runs-on: medication-tracker
-    
+    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,21 +32,21 @@ jobs:
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           TAG="pr-${PR_NUMBER}"
-          
+
           echo "Deleting Docker Hub image: skjall/medication-tracker:${TAG}"
-          
+
           # Get Docker Hub token
           TOKEN=$(curl -s -X POST \
             -H "Content-Type: application/json" \
             -d '{"username":"'${{ secrets.DOCKERHUB_USERNAME }}'","password":"'${{ secrets.DOCKERHUB_TOKEN }}'"}' \
             https://hub.docker.com/v2/users/login/ | jq -r .token)
-          
+
           if [ ! -z "$TOKEN" ]; then
             # Delete the specific tag
             curl -X DELETE \
               -H "Authorization: Bearer ${TOKEN}" \
               "https://hub.docker.com/v2/repositories/skjall/medication-tracker/tags/${TAG}/"
-            
+
             echo "Docker Hub image tag ${TAG} deletion requested"
           else
             echo "Failed to authenticate with Docker Hub"
@@ -57,9 +57,9 @@ jobs:
           PR_NUMBER=${{ github.event.pull_request.number }}
           TAG="pr-${PR_NUMBER}"
           REPO_NAME=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          
+
           echo "Deleting GitHub Container Registry image: ghcr.io/${REPO_NAME}:${TAG}"
-          
+
           # Get package versions for the PR tag
           PACKAGE_VERSION_ID=$(gh api \
             -H "Accept: application/vnd.github+json" \
@@ -67,17 +67,17 @@ jobs:
             "/user/packages/container/$(basename ${REPO_NAME})/versions" \
             --jq '.[] | select(.metadata.container.tags[] | contains("'${TAG}'")) | .id' \
             2>/dev/null || echo "")
-          
+
           if [ ! -z "$PACKAGE_VERSION_ID" ]; then
             echo "Found package version ID: ${PACKAGE_VERSION_ID}"
-            
+
             # Delete the package version
             gh api \
               --method DELETE \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "/user/packages/container/$(basename ${REPO_NAME})/versions/${PACKAGE_VERSION_ID}"
-            
+
             echo "GitHub Container Registry image deleted successfully"
           else
             echo "No matching package version found for tag ${TAG} (may have been already deleted or doesn't exist)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for smaller image size
-FROM python:3.13-slim@sha256:9ed09f78253eb4f029f3d99e07c064f138a6f1394932c3807b3d0738a674d33b AS builder
+FROM python:3.13-slim@sha256:f2fdaec50160418e0c2867ba3e254755edd067171725886d5d303fd7057bbf81 AS builder
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Final stage with minimal dependencies
-FROM python:3.13-slim@sha256:9ed09f78253eb4f029f3d99e07c064f138a6f1394932c3807b3d0738a674d33b
+FROM python:3.13-slim@sha256:f2fdaec50160418e0c2867ba3e254755edd067171725886d5d303fd7057bbf81
 
 # Define VERSION as a build argument
 ARG VERSION=0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for smaller image size
-FROM python:3.13-slim@sha256:d97b595c5f4ac718102e5a5a91adaf04b22e852961a698411637c718d45867c8 AS builder
+FROM python:3.13-slim@sha256:9ed09f78253eb4f029f3d99e07c064f138a6f1394932c3807b3d0738a674d33b AS builder
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Final stage with minimal dependencies
-FROM python:3.13-slim@sha256:d97b595c5f4ac718102e5a5a91adaf04b22e852961a698411637c718d45867c8
+FROM python:3.13-slim@sha256:9ed09f78253eb4f029f3d99e07c064f138a6f1394932c3807b3d0738a674d33b
 
 # Define VERSION as a build argument
 ARG VERSION=0.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ gunicorn==23.0.0
 pytz==2025.2
 pypdf==5.6.0
 tzlocal==5.3.1
-alembic==1.16.1
+alembic==1.16.2


### PR DESCRIPTION
This pull request introduces improvements to the CI/CD pipeline for handling Docker images associated with pull requests. It adds automated workflows for building, tagging, pushing, and cleaning up Docker images for each PR, and updates the Docker base image for security and consistency.

**CI/CD pipeline enhancements for PR Docker images:**

* Added a new `docker-pr` job in `.github/workflows/ci-cd.yml` to build and push Docker images for each pull request, tagging them with the PR number and pushing to both Docker Hub and GitHub Container Registry. This includes steps for setting up build environments, logging in to registries, and adding metadata labels.
* Introduced a new workflow `.github/workflows/pr-cleanup.yml` that automatically deletes Docker images associated with a PR from Docker Hub and GitHub Container Registry when the PR is closed, helping to keep registries clean and reduce storage costs.

**Docker image base update:**

* Updated the base image in both build stages of the `Dockerfile` to a newer `python:3.13-slim` image by changing the referenced SHA256 digest, ensuring the use of the latest security patches and improvements. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L27-R27)